### PR TITLE
add relative probability display

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,5 +10,67 @@
   <body>
     <p class="roll-dice">roll</p>
     <p class="roll-result"></p>
+    <section id="probabilities">
+      <table>
+        <tr>
+          <th>number</th>
+          <th>adjusted dot value</th>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td id="value-2"></td>
+        </tr>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td id="value-3"></td>
+        </tr>
+        </tr>
+        <tr>
+          <td>4</td>
+          <td id="value-4"></td>
+        </tr>
+        </tr>
+        <tr>
+          <td>5</td>
+          <td id="value-5"></td>
+        </tr>
+        </tr>
+        <tr>
+          <td>6</td>
+          <td id="value-6"></td>
+        </tr>
+        </tr>
+        <tr>
+          <td>7</td>
+          <td id="value-7"></td>
+        </tr>
+        </tr>
+        <tr>
+          <td>8</td>
+          <td id="value-8"></td>
+        </tr>
+        </tr>
+        <tr>
+          <td>9</td>
+          <td id="value-9"></td>
+        </tr>
+        </tr>
+        <tr>
+          <td>10</td>
+          <td id="value-10"></td>
+        </tr>
+        </tr>
+        <tr>
+          <td>11</td>
+          <td id="value-11"></td>
+        </tr>
+        </tr>
+        <tr>
+          <td>12</td>
+          <td id="value-12"></td>
+        </tr>
+      </table>
+    </section>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,3 @@
+.roll-result {
+  min-height: 1em;
+}


### PR DESCRIPTION
This PR adds a feature that shows adjusted dot values for each number, removing the need for players to 'count cards' to get the relative probability of the numbers for each roll.  The dot values are shown in the familiar numerator to 36 format.